### PR TITLE
fix: persist download failure details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### TUI
 - `Flash!` in `inc/isoforge.sh` now redirects users to drive selection when no drive is chosen, keeps the current image selection intact, and continues into the flash confirmation flow after a drive is picked.
 - Added `scripts/test-flash-drive-redirect.sh` and wired it into `./test` to keep the redirect behavior covered.
+- Download failures now persist their latest summary, source, URL, timestamp, and `/tmp` log path in session state so the details remain visible in the `isoforge` main status panel after the error dialog is dismissed.
+- `./download` now prints the last tracked download failure summary and log path at the end of a failed run.
+- Added `scripts/test-download-error-state.sh` and wired it into `./test` to keep the persisted error summary behavior covered.
 
 ## 2026-03-08
 

--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,5 @@
 inc/isoforge.sh usr/bin/isoforge
+inc/ usr/share/isoforge/inc/
 config.json usr/share/isoforge/config.json
 VERSION usr/share/isoforge/VERSION
 scripts/ usr/share/isoforge/scripts/

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -83,11 +83,14 @@ print_last_download_error_cli() {
 
 derive_download_output_name() {
   local url="$1"
-  local output
+  local output candidate
 
   output=$(basename -- "$url")
   if [[ "$output" != *.* ]]; then
-    output=$(printf '%s\n' "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
+    candidate=$(printf '%s\n' "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
+    if [[ -n "$candidate" && "$candidate" != *://* && "$candidate" != */* ]]; then
+      output="$candidate"
+    fi
   fi
   printf '%s\n' "$output"
 }

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -167,14 +167,14 @@ download_file_with_error_tracking() {
           cur_bytes=$(wc -c <"$tmpfile" 2>/dev/null || echo 0)
         fi
         percent=$(( (percent + 3) % 100 ))
-        printf 'XXX\n%d\n' "$percent"
-        printf 'Downloading: %s\n' "$(basename -- "$output")"
-        printf 'Downloaded: %s bytes\n' "$cur_bytes"
-        printf 'XXX\n'
+        printf 'XXX\n%d\n' "$percent" || break
+        printf 'Downloading: %s\n' "$(basename -- "$output")" || break
+        printf 'Downloaded: %s bytes\n' "$cur_bytes" || break
+        printf 'XXX\n' || break
         sleep 1
       done
-      printf 'XXX\n100\nFinalizing...\nXXX\n'
-    ) | dialog --no-shadow --title "Downloading" --gauge "Preparing download..." 12 72 0
+      printf 'XXX\n100\nFinalizing...\nXXX\n' || true
+    ) 2>/dev/null | dialog --no-shadow --title "Downloading" --gauge "Preparing download..." 12 72 0
     dlg_rc=$?
     if (( dialog_errexit_was_on )); then
       set -e
@@ -215,7 +215,7 @@ download_file_with_error_tracking() {
     set -e
   fi
   if (( rc == 0 )); then
-    local mv_rc rm_rc op_rc err_preview
+    local mv_rc rm_rc err_preview
     if (( function_errexit_was_on )); then
       set +e
     fi
@@ -229,12 +229,11 @@ download_file_with_error_tracking() {
     if (( function_errexit_was_on )); then
       set -e
     fi
-    if (( mv_rc == 0 && rm_rc == 0 )); then
+    if (( mv_rc == 0 )); then
+      if (( rm_rc != 0 )); then
+        printf 'warning: failed to remove temporary download log: %s\n' "$log_file" >&2
+      fi
       return 0
-    fi
-    op_rc=$mv_rc
-    if (( op_rc == 0 )); then
-      op_rc=$rm_rc
     fi
     if (( mv_rc != 0 )); then
       rm -f -- "$tmpfile"
@@ -257,11 +256,11 @@ download_file_with_error_tracking() {
       "$url" \
       "$log_file" \
       "$err_preview" \
-      "$op_rc"
+      "$mv_rc"
     if command -v dialog >/dev/null 2>&1; then
       show_last_download_error_dialog || true
     fi
-    return "$op_rc"
+    return "$mv_rc"
   fi
 
   rm -f -- "$tmpfile"

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+LAST_DOWNLOAD_ERROR_TIME="${LAST_DOWNLOAD_ERROR_TIME:-}"
+LAST_DOWNLOAD_ERROR_OPERATION="${LAST_DOWNLOAD_ERROR_OPERATION:-}"
+LAST_DOWNLOAD_ERROR_SOURCE="${LAST_DOWNLOAD_ERROR_SOURCE:-}"
+LAST_DOWNLOAD_ERROR_URL="${LAST_DOWNLOAD_ERROR_URL:-}"
+LAST_DOWNLOAD_ERROR_LOG="${LAST_DOWNLOAD_ERROR_LOG:-}"
+LAST_DOWNLOAD_ERROR_MESSAGE="${LAST_DOWNLOAD_ERROR_MESSAGE:-}"
+LAST_DOWNLOAD_ERROR_RC="${LAST_DOWNLOAD_ERROR_RC:-}"
+
+clear_last_download_error() {
+  LAST_DOWNLOAD_ERROR_TIME=""
+  LAST_DOWNLOAD_ERROR_OPERATION=""
+  LAST_DOWNLOAD_ERROR_SOURCE=""
+  LAST_DOWNLOAD_ERROR_URL=""
+  LAST_DOWNLOAD_ERROR_LOG=""
+  LAST_DOWNLOAD_ERROR_MESSAGE=""
+  LAST_DOWNLOAD_ERROR_RC=""
+}
+
+record_last_download_error() {
+  LAST_DOWNLOAD_ERROR_TIME="${1:-}"
+  LAST_DOWNLOAD_ERROR_OPERATION="${2:-}"
+  LAST_DOWNLOAD_ERROR_SOURCE="${3:-}"
+  LAST_DOWNLOAD_ERROR_URL="${4:-}"
+  LAST_DOWNLOAD_ERROR_LOG="${5:-}"
+  LAST_DOWNLOAD_ERROR_MESSAGE="${6:-}"
+  LAST_DOWNLOAD_ERROR_RC="${7:-}"
+}
+
+has_last_download_error() {
+  [[ -n "${LAST_DOWNLOAD_ERROR_TIME:-}" ]]
+}
+
+last_download_error_summary() {
+  if ! has_last_download_error; then
+    return 1
+  fi
+
+  printf 'Last download error: [%s] %s %s\n' \
+    "$LAST_DOWNLOAD_ERROR_TIME" \
+    "${LAST_DOWNLOAD_ERROR_OPERATION:-download}" \
+    "${LAST_DOWNLOAD_ERROR_SOURCE:-unknown source}"
+  printf 'Reason: %s\n' "${LAST_DOWNLOAD_ERROR_MESSAGE:-unknown error}"
+  printf 'URL: %s\n' "${LAST_DOWNLOAD_ERROR_URL:-unknown}"
+  printf 'Log: %s\n' "${LAST_DOWNLOAD_ERROR_LOG:-unavailable}"
+}
+
+show_last_download_error_dialog() {
+  has_last_download_error || return 1
+  dialog --title "Download Error" --msgbox "$(last_download_error_summary)" 14 76
+}
+
+print_last_download_error_cli() {
+  has_last_download_error || return 1
+  printf '%s\n' "$(last_download_error_summary)"
+}
+
+download_file_with_error_tracking() {
+  local url="$1"
+  local output="${2:-}"
+  local operation="${3:-download}"
+  local source_ref="${4:-$url}"
+
+  if [[ -z "$output" ]]; then
+    output=$(basename "$url")
+    if [[ "$output" != *.* ]]; then
+      output=$(echo "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
+    fi
+  fi
+
+  local dir tmpfile log_file
+  dir=$(dirname -- "$output")
+  if [[ -n "$dir" && "$dir" != "." ]] && [[ ! -d "$dir" ]]; then
+    mkdir -p "$dir" || return 1
+  fi
+  tmpfile="${output}.part"
+  log_file=$(mktemp "/tmp/isoforge-download.XXXXXXXX.log")
+  rm -f "$tmpfile"
+
+  local tool
+  if command -v curl >/dev/null 2>&1; then
+    tool="curl"
+  elif command -v wget >/dev/null 2>&1; then
+    tool="wget"
+  else
+    printf 'Neither curl nor wget is installed.\n' >"$log_file"
+    record_last_download_error \
+      "$(date '+%Y-%m-%d %H:%M:%S %Z')" \
+      "$operation" \
+      "$source_ref" \
+      "$url" \
+      "$log_file" \
+      "Neither curl nor wget is installed." \
+      "127"
+    return 127
+  fi
+
+  local -a cmd
+  if [[ "$tool" == "curl" ]]; then
+    cmd=(curl -L --fail -sS -o "$tmpfile" "$url")
+  else
+    cmd=(wget -q -O "$tmpfile" "$url")
+  fi
+
+  "${cmd[@]}" >"$log_file" 2>&1 &
+  local pid=$!
+
+  if command -v dialog >/dev/null 2>&1; then
+    (
+      local percent=0 cur_bytes
+      while kill -0 "$pid" >/dev/null 2>&1; do
+        cur_bytes=0
+        if [[ -f "$tmpfile" ]]; then
+          cur_bytes=$(wc -c <"$tmpfile" 2>/dev/null || echo 0)
+        fi
+        percent=$(( (percent + 3) % 100 ))
+        printf 'XXX\n%d\n' "$percent"
+        printf 'Downloading: %s\n' "$(basename -- "$output")"
+        printf 'Downloaded: %s bytes\n' "$cur_bytes"
+        printf 'XXX\n'
+        sleep 1
+      done
+      printf 'XXX\n100\nFinalizing...\nXXX\n'
+    ) | dialog --no-shadow --title "Downloading" --gauge "Preparing download..." 12 72 0
+    local dlg_rc=$?
+    if (( dlg_rc != 0 )); then
+      if kill -0 "$pid" >/dev/null 2>&1; then
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+      fi
+      rm -f "$tmpfile" "$log_file"
+      return 1
+    fi
+  fi
+
+  local rc
+  set +e
+  wait "$pid"
+  rc=$?
+  set -e
+  if (( rc == 0 )); then
+    mv -f "$tmpfile" "$output"
+    rm -f "$log_file"
+    clear_last_download_error
+    return 0
+  fi
+
+  rm -f "$tmpfile"
+  local err_preview
+  if [[ -s "$log_file" ]]; then
+    err_preview=$(tail -n 20 "$log_file")
+  else
+    err_preview="No additional error output captured."
+  fi
+  record_last_download_error \
+    "$(date '+%Y-%m-%d %H:%M:%S %Z')" \
+    "$operation" \
+    "$source_ref" \
+    "$url" \
+    "$log_file" \
+    "$err_preview" \
+    "$rc"
+  if command -v dialog >/dev/null 2>&1; then
+    show_last_download_error_dialog || true
+  fi
+  return "$rc"
+}

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -53,6 +53,21 @@ record_last_download_error() {
   LAST_DOWNLOAD_ERROR_RC="${7:-}"
 }
 
+summarize_download_error_message() {
+  local raw="${1:-}"
+  local single_line
+  local limit=200
+
+  single_line=$(printf '%s\n' "$raw" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
+  if [[ -z "$single_line" ]]; then
+    single_line="No additional error output captured."
+  fi
+  if (( ${#single_line} > limit )); then
+    single_line="${single_line:0:limit-3}..."
+  fi
+  printf '%s\n' "$single_line"
+}
+
 has_last_download_error() {
   [[ -n "${LAST_DOWNLOAD_ERROR_TIME:-}" ]]
 }
@@ -127,6 +142,9 @@ download_file_with_error_tracking() {
         "$log_file" \
         "Failed to create output directory \"$dir\"." \
         "1"
+      if command -v dialog >/dev/null 2>&1; then
+        show_last_download_error_dialog || true
+      fi
       return 1
     fi
   fi
@@ -149,6 +167,9 @@ download_file_with_error_tracking() {
       "$log_file" \
       "Neither curl nor wget is installed." \
       "127"
+    if command -v dialog >/dev/null 2>&1; then
+      show_last_download_error_dialog || true
+    fi
     return 127
   fi
 
@@ -258,7 +279,7 @@ download_file_with_error_tracking() {
       printf '\nFailed to remove temporary download log.\n' >>"$log_file"
     fi
     if [[ -s "$log_file" ]]; then
-      err_preview=$(tail -n 20 "$log_file")
+      err_preview=$(summarize_download_error_message "$(tail -n 20 "$log_file")")
     else
       err_preview="No additional error output captured."
     fi
@@ -279,7 +300,7 @@ download_file_with_error_tracking() {
   rm -f -- "$tmpfile"
   local err_preview
   if [[ -s "$log_file" ]]; then
-    err_preview=$(tail -n 20 "$log_file")
+    err_preview=$(summarize_download_error_message "$(tail -n 20 "$log_file")")
   else
     err_preview="No additional error output captured."
   fi

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -71,6 +71,17 @@ print_last_download_error_cli() {
   printf '%s\n' "$(last_download_error_summary)"
 }
 
+derive_download_output_name() {
+  local url="$1"
+  local output
+
+  output=$(basename -- "$url")
+  if [[ "$output" != *.* ]]; then
+    output=$(printf '%s\n' "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
+  fi
+  printf '%s\n' "$output"
+}
+
 download_file_with_error_tracking() {
   local url="$1"
   local output="${2:-}"
@@ -83,10 +94,7 @@ download_file_with_error_tracking() {
   fi
 
   if [[ -z "$output" ]]; then
-    output=$(basename "$url")
-    if [[ "$output" != *.* ]]; then
-      output=$(echo "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
-    fi
+    output=$(derive_download_output_name "$url")
   fi
 
   local dir tmpfile log_file mkdir_err

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -122,10 +122,14 @@ download_file_with_error_tracking() {
   local pid=$!
 
   if command -v dialog >/dev/null 2>&1; then
-    local pipefail_was_on=0 dlg_rc
+    local pipefail_was_on=0 errexit_was_on=0 dlg_rc
     if shopt -qo pipefail; then
       pipefail_was_on=1
       set +o pipefail
+    fi
+    if [[ $- == *e* ]]; then
+      errexit_was_on=1
+      set +e
     fi
     (
       local percent=0 cur_bytes
@@ -144,6 +148,9 @@ download_file_with_error_tracking() {
       printf 'XXX\n100\nFinalizing...\nXXX\n'
     ) | dialog --no-shadow --title "Downloading" --gauge "Preparing download..." 12 72 0
     dlg_rc=$?
+    if (( errexit_was_on )); then
+      set -e
+    fi
     if (( pipefail_was_on )); then
       set -o pipefail
     fi

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -10,10 +10,20 @@ LAST_DOWNLOAD_ERROR_RC="${LAST_DOWNLOAD_ERROR_RC:-}"
 
 cleanup_tracked_download_log() {
   local log_path="${1:-}"
+  local cleanup_errexit_was_on=0
 
   if [[ "$log_path" == /tmp/isoforge-download.*.log ]] && [[ -f "$log_path" ]]; then
+    if [[ $- == *e* ]]; then
+      cleanup_errexit_was_on=1
+      set +e
+    fi
     rm -f -- "$log_path"
+    if (( cleanup_errexit_was_on )); then
+      set -e
+    fi
   fi
+
+  return 0
 }
 
 clear_last_download_error() {

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -8,7 +8,16 @@ LAST_DOWNLOAD_ERROR_LOG="${LAST_DOWNLOAD_ERROR_LOG:-}"
 LAST_DOWNLOAD_ERROR_MESSAGE="${LAST_DOWNLOAD_ERROR_MESSAGE:-}"
 LAST_DOWNLOAD_ERROR_RC="${LAST_DOWNLOAD_ERROR_RC:-}"
 
+cleanup_tracked_download_log() {
+  local log_path="${1:-}"
+
+  if [[ "$log_path" == /tmp/isoforge-download.*.log ]] && [[ -f "$log_path" ]]; then
+    rm -f "$log_path"
+  fi
+}
+
 clear_last_download_error() {
+  cleanup_tracked_download_log "${LAST_DOWNLOAD_ERROR_LOG:-}"
   LAST_DOWNLOAD_ERROR_TIME=""
   LAST_DOWNLOAD_ERROR_OPERATION=""
   LAST_DOWNLOAD_ERROR_SOURCE=""
@@ -19,6 +28,12 @@ clear_last_download_error() {
 }
 
 record_last_download_error() {
+  local previous_log="${LAST_DOWNLOAD_ERROR_LOG:-}"
+  local next_log="${5:-}"
+
+  if [[ -n "$previous_log" && "$previous_log" != "$next_log" ]]; then
+    cleanup_tracked_download_log "$previous_log"
+  fi
   LAST_DOWNLOAD_ERROR_TIME="${1:-}"
   LAST_DOWNLOAD_ERROR_OPERATION="${2:-}"
   LAST_DOWNLOAD_ERROR_SOURCE="${3:-}"
@@ -120,7 +135,7 @@ download_file_with_error_tracking() {
   if [[ "$tool" == "curl" ]]; then
     cmd=(curl -L --fail -sS -o "$tmpfile" "$url")
   else
-    cmd=(wget -q -O "$tmpfile" "$url")
+    cmd=(wget -nv -O "$tmpfile" "$url")
   fi
 
   "${cmd[@]}" >"$log_file" 2>&1 &
@@ -198,8 +213,11 @@ download_file_with_error_tracking() {
     fi
     mv -f "$tmpfile" "$output"
     mv_rc=$?
-    rm -f "$log_file"
-    rm_rc=$?
+    rm_rc=0
+    if (( mv_rc == 0 )); then
+      rm -f "$log_file"
+      rm_rc=$?
+    fi
     if (( function_errexit_was_on )); then
       set -e
     fi

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -129,8 +129,21 @@ download_file_with_error_tracking() {
         kill "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true
       fi
-      rm -f "$tmpfile" "$log_file"
-      return 1
+      rm -f "$tmpfile"
+      local err_preview="Download canceled by user via dialog."
+      printf '%s\n' "$err_preview" >"$log_file"
+      record_last_download_error \
+        "$(date '+%Y-%m-%d %H:%M:%S %Z')" \
+        "$operation" \
+        "$source_ref" \
+        "$url" \
+        "$log_file" \
+        "$err_preview" \
+        "$dlg_rc"
+      if command -v dialog >/dev/null 2>&1; then
+        show_last_download_error_dialog || true
+      fi
+      return "$dlg_rc"
     fi
   fi
 
@@ -142,7 +155,6 @@ download_file_with_error_tracking() {
   if (( rc == 0 )); then
     mv -f "$tmpfile" "$output"
     rm -f "$log_file"
-    clear_last_download_error
     return 0
   fi
 

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -12,7 +12,7 @@ cleanup_tracked_download_log() {
   local log_path="${1:-}"
   local cleanup_errexit_was_on=0
 
-  if [[ "$log_path" == /tmp/isoforge-download.*.log ]] && [[ -f "$log_path" ]]; then
+  if [[ "$log_path" =~ ^/tmp/isoforge-download\.[A-Za-z0-9._-]+\.log$ ]] && [[ -f "$log_path" ]]; then
     if [[ $- == *e* ]]; then
       cleanup_errexit_was_on=1
       set +e

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -61,6 +61,11 @@ download_file_with_error_tracking() {
   local output="${2:-}"
   local operation="${3:-download}"
   local source_ref="${4:-$url}"
+  local function_errexit_was_on=0
+
+  if [[ $- == *e* ]]; then
+    function_errexit_was_on=1
+  fi
 
   if [[ -z "$output" ]]; then
     output=$(basename "$url")
@@ -122,13 +127,13 @@ download_file_with_error_tracking() {
   local pid=$!
 
   if command -v dialog >/dev/null 2>&1; then
-    local pipefail_was_on=0 errexit_was_on=0 dlg_rc
+    local pipefail_was_on=0 dialog_errexit_was_on=0 dlg_rc
     if shopt -qo pipefail; then
       pipefail_was_on=1
       set +o pipefail
     fi
     if [[ $- == *e* ]]; then
-      errexit_was_on=1
+      dialog_errexit_was_on=1
       set +e
     fi
     (
@@ -148,7 +153,7 @@ download_file_with_error_tracking() {
       printf 'XXX\n100\nFinalizing...\nXXX\n'
     ) | dialog --no-shadow --title "Downloading" --gauge "Preparing download..." 12 72 0
     dlg_rc=$?
-    if (( errexit_was_on )); then
+    if (( dialog_errexit_was_on )); then
       set -e
     fi
     if (( pipefail_was_on )); then
@@ -157,8 +162,8 @@ download_file_with_error_tracking() {
     if (( dlg_rc != 0 )); then
       if kill -0 "$pid" >/dev/null 2>&1; then
         kill "$pid" 2>/dev/null || true
-        wait "$pid" 2>/dev/null || true
       fi
+      wait "$pid" 2>/dev/null || true
       rm -f "$tmpfile"
       local err_preview="Download canceled by user via dialog."
       printf '%s\n' "$err_preview" >"$log_file"
@@ -178,18 +183,26 @@ download_file_with_error_tracking() {
   fi
 
   local rc
-  set +e
+  if (( function_errexit_was_on )); then
+    set +e
+  fi
   wait "$pid"
   rc=$?
-  set -e
+  if (( function_errexit_was_on )); then
+    set -e
+  fi
   if (( rc == 0 )); then
     local mv_rc rm_rc op_rc err_preview
-    set +e
+    if (( function_errexit_was_on )); then
+      set +e
+    fi
     mv -f "$tmpfile" "$output"
     mv_rc=$?
     rm -f "$log_file"
     rm_rc=$?
-    set -e
+    if (( function_errexit_was_on )); then
+      set -e
+    fi
     if (( mv_rc == 0 && rm_rc == 0 )); then
       return 0
     fi

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -69,10 +69,25 @@ download_file_with_error_tracking() {
     fi
   fi
 
-  local dir tmpfile log_file
+  local dir tmpfile log_file mkdir_err
   dir=$(dirname -- "$output")
   if [[ -n "$dir" && "$dir" != "." ]] && [[ ! -d "$dir" ]]; then
-    mkdir -p "$dir" || return 1
+    if ! mkdir_err=$(mkdir -p "$dir" 2>&1); then
+      log_file=$(mktemp "/tmp/isoforge-download.XXXXXXXX.log")
+      {
+        printf 'Failed to create output directory "%s" for download.\n' "$dir"
+        printf 'mkdir output:\n%s\n' "$mkdir_err"
+      } >"$log_file"
+      record_last_download_error \
+        "$(date '+%Y-%m-%d %H:%M:%S %Z')" \
+        "$operation" \
+        "$source_ref" \
+        "$url" \
+        "$log_file" \
+        "Failed to create output directory \"$dir\"." \
+        "1"
+      return 1
+    fi
   fi
   tmpfile="${output}.part"
   log_file=$(mktemp "/tmp/isoforge-download.XXXXXXXX.log")
@@ -107,6 +122,11 @@ download_file_with_error_tracking() {
   local pid=$!
 
   if command -v dialog >/dev/null 2>&1; then
+    local pipefail_was_on=0 dlg_rc
+    if shopt -qo pipefail; then
+      pipefail_was_on=1
+      set +o pipefail
+    fi
     (
       local percent=0 cur_bytes
       while kill -0 "$pid" >/dev/null 2>&1; do
@@ -123,7 +143,10 @@ download_file_with_error_tracking() {
       done
       printf 'XXX\n100\nFinalizing...\nXXX\n'
     ) | dialog --no-shadow --title "Downloading" --gauge "Preparing download..." 12 72 0
-    local dlg_rc=$?
+    dlg_rc=$?
+    if (( pipefail_was_on )); then
+      set -o pipefail
+    fi
     if (( dlg_rc != 0 )); then
       if kill -0 "$pid" >/dev/null 2>&1; then
         kill "$pid" 2>/dev/null || true
@@ -153,9 +176,46 @@ download_file_with_error_tracking() {
   rc=$?
   set -e
   if (( rc == 0 )); then
+    local mv_rc rm_rc op_rc err_preview
+    set +e
     mv -f "$tmpfile" "$output"
+    mv_rc=$?
     rm -f "$log_file"
-    return 0
+    rm_rc=$?
+    set -e
+    if (( mv_rc == 0 && rm_rc == 0 )); then
+      return 0
+    fi
+    op_rc=$mv_rc
+    if (( op_rc == 0 )); then
+      op_rc=$rm_rc
+    fi
+    if (( mv_rc != 0 )); then
+      rm -f "$tmpfile"
+    fi
+    if (( mv_rc != 0 )); then
+      printf '\nFailed to move downloaded file into place.\n' >>"$log_file"
+    fi
+    if (( rm_rc != 0 )); then
+      printf '\nFailed to remove temporary download log.\n' >>"$log_file"
+    fi
+    if [[ -s "$log_file" ]]; then
+      err_preview=$(tail -n 20 "$log_file")
+    else
+      err_preview="No additional error output captured."
+    fi
+    record_last_download_error \
+      "$(date '+%Y-%m-%d %H:%M:%S %Z')" \
+      "$operation" \
+      "$source_ref" \
+      "$url" \
+      "$log_file" \
+      "$err_preview" \
+      "$op_rc"
+    if command -v dialog >/dev/null 2>&1; then
+      show_last_download_error_dialog || true
+    fi
+    return "$op_rc"
   fi
 
   rm -f "$tmpfile"

--- a/inc/download-state.sh
+++ b/inc/download-state.sh
@@ -12,7 +12,7 @@ cleanup_tracked_download_log() {
   local log_path="${1:-}"
 
   if [[ "$log_path" == /tmp/isoforge-download.*.log ]] && [[ -f "$log_path" ]]; then
-    rm -f "$log_path"
+    rm -f -- "$log_path"
   fi
 }
 
@@ -92,7 +92,7 @@ download_file_with_error_tracking() {
   local dir tmpfile log_file mkdir_err
   dir=$(dirname -- "$output")
   if [[ -n "$dir" && "$dir" != "." ]] && [[ ! -d "$dir" ]]; then
-    if ! mkdir_err=$(mkdir -p "$dir" 2>&1); then
+    if ! mkdir_err=$(mkdir -p -- "$dir" 2>&1); then
       log_file=$(mktemp "/tmp/isoforge-download.XXXXXXXX.log")
       {
         printf 'Failed to create output directory "%s" for download.\n' "$dir"
@@ -111,7 +111,7 @@ download_file_with_error_tracking() {
   fi
   tmpfile="${output}.part"
   log_file=$(mktemp "/tmp/isoforge-download.XXXXXXXX.log")
-  rm -f "$tmpfile"
+  rm -f -- "$tmpfile"
 
   local tool
   if command -v curl >/dev/null 2>&1; then
@@ -133,9 +133,9 @@ download_file_with_error_tracking() {
 
   local -a cmd
   if [[ "$tool" == "curl" ]]; then
-    cmd=(curl -L --fail -sS -o "$tmpfile" "$url")
+    cmd=(curl -L --fail -sS -o "$tmpfile" -- "$url")
   else
-    cmd=(wget -nv -O "$tmpfile" "$url")
+    cmd=(wget -nv -O "$tmpfile" -- "$url")
   fi
 
   "${cmd[@]}" >"$log_file" 2>&1 &
@@ -179,7 +179,7 @@ download_file_with_error_tracking() {
         kill "$pid" 2>/dev/null || true
       fi
       wait "$pid" 2>/dev/null || true
-      rm -f "$tmpfile"
+      rm -f -- "$tmpfile"
       local err_preview="Download canceled by user via dialog."
       printf '%s\n' "$err_preview" >"$log_file"
       record_last_download_error \
@@ -211,11 +211,11 @@ download_file_with_error_tracking() {
     if (( function_errexit_was_on )); then
       set +e
     fi
-    mv -f "$tmpfile" "$output"
+    mv -f -- "$tmpfile" "$output"
     mv_rc=$?
     rm_rc=0
     if (( mv_rc == 0 )); then
-      rm -f "$log_file"
+      rm -f -- "$log_file"
       rm_rc=$?
     fi
     if (( function_errexit_was_on )); then
@@ -229,7 +229,7 @@ download_file_with_error_tracking() {
       op_rc=$rm_rc
     fi
     if (( mv_rc != 0 )); then
-      rm -f "$tmpfile"
+      rm -f -- "$tmpfile"
     fi
     if (( mv_rc != 0 )); then
       printf '\nFailed to move downloaded file into place.\n' >>"$log_file"
@@ -256,7 +256,7 @@ download_file_with_error_tracking() {
     return "$op_rc"
   fi
 
-  rm -f "$tmpfile"
+  rm -f -- "$tmpfile"
   local err_preview
   if [[ -s "$log_file" ]]; then
     err_preview=$(tail -n 20 "$log_file")

--- a/inc/download.sh
+++ b/inc/download.sh
@@ -22,6 +22,7 @@ fi
 # shellcheck source=/dev/null
 source "$SCRIPT_HELPERS_DIR/helpers.sh"
 shlib_import logging dialog file os deps
+# shellcheck source=/dev/null
 source "$REPO_ROOT/inc/download-state.sh"
 
 # Always restore a clean terminal UI when exiting (including Cancel/interrupt)
@@ -153,6 +154,7 @@ selected=$(dialog --stdout --title "Download ISOs" --checklist "Select one or mo
 selected=$(sed 's/\"//g' <<<"$selected")
 
 pushd "$DOWNLOAD_DIR" >/dev/null
+clear_last_download_error
 errors=0
 for id in $selected; do
   # Skip category headers if user selected them

--- a/inc/download.sh
+++ b/inc/download.sh
@@ -22,6 +22,7 @@ fi
 # shellcheck source=/dev/null
 source "$SCRIPT_HELPERS_DIR/helpers.sh"
 shlib_import logging dialog file os deps
+source "$REPO_ROOT/inc/download-state.sh"
 
 # Always restore a clean terminal UI when exiting (including Cancel/interrupt)
 reset_tui() { tput cnorm 2>/dev/null || true; tput rmcup 2>/dev/null || true; clear; }
@@ -173,8 +174,7 @@ for id in $selected; do
   if [[ "$output" != *.* ]]; then
     output=$(echo "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
   fi
-  # Script-helpers handles dialog progress + failure details.
-  if ! download_file "$url" "$output"; then
+  if ! download_file_with_error_tracking "$url" "$output" "batch-download" "$id"; then
     print_error "Failed to download $id"
     errors=$((errors+1))
   fi
@@ -185,6 +185,9 @@ if [[ "$errors" -eq 0 ]]; then
   print_success "Download completed! Files saved to $DOWNLOAD_DIR"
 else
   print_warning "Completed with $errors error(s). Check logs."
+  if has_last_download_error; then
+    print_last_download_error_cli
+  fi
 fi
 
 # End of script

--- a/inc/download.sh
+++ b/inc/download.sh
@@ -22,8 +22,14 @@ fi
 # shellcheck source=/dev/null
 source "$SCRIPT_HELPERS_DIR/helpers.sh"
 shlib_import logging dialog file os deps
-# shellcheck source=/dev/null
-source "$REPO_ROOT/inc/download-state.sh"
+if [[ -f "$REPO_ROOT/inc/download-state.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "$REPO_ROOT/inc/download-state.sh"
+else
+  >&2 printf "Missing required state file: %s\n" "$REPO_ROOT/inc/download-state.sh"
+  >&2 printf "This script appears to be running from a partial or incomplete installation.\n"
+  exit 1
+fi
 
 # Always restore a clean terminal UI when exiting (including Cancel/interrupt)
 reset_tui() { tput cnorm 2>/dev/null || true; tput rmcup 2>/dev/null || true; clear; }

--- a/inc/download.sh
+++ b/inc/download.sh
@@ -178,10 +178,7 @@ for id in $selected; do
     errors=$((errors+1))
     continue
   fi
-  output=$(basename "$url")
-  if [[ "$output" != *.* ]]; then
-    output=$(echo "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
-  fi
+  output=$(derive_download_output_name "$url")
   if ! download_file_with_error_tracking "$url" "$output" "batch-download" "$id"; then
     print_error "Failed to download $id"
     errors=$((errors+1))

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -308,7 +308,7 @@ select_images_from_config_multi() {
   SELECTED_IMAGES=()
   local -a skipped_insecure=()
   local -a skipped_unsupported=()
-  local id url output path errs=0
+  local id url output path errs=0 download_failed=0
   for id in $chosen; do
     [[ "$id" == hdr_* ]] && continue
     url=$(jq -r --arg id "$id" '.distros[] | select(.id==$id) | .url' "$CONFIG_FILE")
@@ -323,12 +323,12 @@ select_images_from_config_multi() {
       skipped_insecure+=("$id")
       continue
     fi
-    output=$(basename "$url")
-    if [[ "$output" != *.* ]]; then
-      output=$(echo "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
-    fi
+    output=$(derive_download_output_name "$url")
     if [[ ! -f "$output" ]]; then
-      download_file_with_error_tracking "$url" "$output" "multi-download" "$id" || errs=$((errs+1))
+      if ! download_file_with_error_tracking "$url" "$output" "multi-download" "$id"; then
+        errs=$((errs+1))
+        download_failed=1
+      fi
     fi
     path="$DOWNLOAD_DIR/$output"
     if [[ -f "$path" ]]; then SELECTED_IMAGES+=("$path"); fi
@@ -337,7 +337,7 @@ select_images_from_config_multi() {
   if (( errs > 0 )); then
     local detail=""
     local failure_note="If a download fails, the latest failure remains visible in the main status panel."
-    if has_last_download_error; then
+    if (( download_failed == 1 )) && has_last_download_error; then
       failure_note="The latest download failure remains visible in the main status panel."
     fi
     if [[ ${#skipped_insecure[@]} -gt 0 ]]; then
@@ -459,10 +459,7 @@ select_image_from_config() {
 
   pushd "$DOWNLOAD_DIR" >/dev/null
   # Determine output filename (mirrors scripts/lib/file.sh logic)
-  output=$(basename "$url")
-  if [[ "$output" != *.* ]]; then
-    output=$(echo "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
-  fi
+  output=$(derive_download_output_name "$url")
 
   if ! download_file_with_error_tracking "$url" "$output" "single-download" "$chosen"; then
     popd >/dev/null

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -334,22 +334,22 @@ select_images_from_config_multi() {
     if [[ -f "$path" ]]; then SELECTED_IMAGES+=("$path"); fi
   done
   popd >/dev/null
-	  if (( errs > 0 )); then
-	    local detail=""
-	    local failure_note="If a download fails, the latest failure remains visible in the main status panel."
-	    if has_last_download_error; then
-	      failure_note="The latest download failure remains visible in the main status panel."
-	    fi
-	    if [[ ${#skipped_insecure[@]} -gt 0 ]]; then
-	      detail="${detail}\nSkipped insecure (HTTP) selections: ${skipped_insecure[*]}"
-	      detail="${detail}\nHint: set ALLOW_INSECURE_HTTP_DOWNLOADS=1 only if you explicitly accept insecure downloads."
-	    fi
+  if (( errs > 0 )); then
+    local detail=""
+    local failure_note="If a download fails, the latest failure remains visible in the main status panel."
+    if has_last_download_error; then
+      failure_note="The latest download failure remains visible in the main status panel."
+    fi
+    if [[ ${#skipped_insecure[@]} -gt 0 ]]; then
+      detail="${detail}\nSkipped insecure (HTTP) selections: ${skipped_insecure[*]}"
+      detail="${detail}\nHint: set ALLOW_INSECURE_HTTP_DOWNLOADS=1 only if you explicitly accept insecure downloads."
+    fi
     if [[ ${#skipped_unsupported[@]} -gt 0 ]]; then
       detail="${detail}\nSkipped unsupported URL selections: ${skipped_unsupported[*]}"
-	    fi
-	    dialog --title "Download completed with warnings" --msgbox \
-	      "Some selected items could not be processed (${errs}).\nThis may be due to missing URLs, unsupported URL schemes, insecure URL rejection, or download failures.\nOnly successfully downloaded files were kept in the selection.\n\n${failure_note}${detail}" 16 74
-	  fi
+    fi
+    dialog --title "Download completed with warnings" --msgbox \
+      "Some selected items could not be processed (${errs}).\nThis may be due to missing URLs, unsupported URL schemes, insecure URL rejection, or download failures.\nOnly successfully downloaded files were kept in the selection.\n\n${failure_note}${detail}" 16 74
+  fi
   if [[ ${#SELECTED_IMAGES[@]} -eq 1 ]]; then
     SELECTED_IMAGE="${SELECTED_IMAGES[0]}"
   elif [[ ${#SELECTED_IMAGES[@]} -gt 1 ]]; then

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -256,6 +256,17 @@ show_summary() {
   fi
 }
 
+show_about_dialog() {
+  dialog_init
+  dialog --title "About burn-iso" --msgbox \
+"burn-iso helps download Linux images and write them to removable media from a dialog-based CLI.
+
+Author profiles
+GitHub: https://github.com/nikolareljin
+LinkedIn: https://www.linkedin.com/in/nikolareljin" \
+    13 76
+}
+
 select_image_source() {
   dialog_init
   local choice
@@ -901,6 +912,7 @@ main_menu() {
       image  "Select Image(s)" \
       bg     "Select Ventoy Background" \
       drive  "Select Drive" \
+      about  "About" \
       flash  "Flash! (dd for single, Ventoy for multi)" \
       quit   "Quit") || break
 
@@ -908,6 +920,7 @@ main_menu() {
       image) if ! run_main_menu_action select_image_source; then :; fi ;;
       bg)    if ! run_main_menu_action select_background_image; then :; fi ;;
       drive) if ! run_main_menu_action select_drive; then :; fi ;;
+      about) show_about_dialog ;;
       flash) if ! run_main_menu_action flash_image; then :; fi ;;
       quit)  break               ;;
     esac

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -39,6 +39,7 @@ fi
 # shellcheck source=/dev/null
 source "$SCRIPT_HELPERS_DIR/helpers.sh"
 shlib_import logging help dialog file os json deps
+source "$REPO_ROOT/inc/download-state.sh"
 
 # Always restore a clean terminal UI when exiting (including Cancel/interrupt)
 reset_tui() { tput cnorm 2>/dev/null || true; tput rmcup 2>/dev/null || true; clear; }
@@ -244,6 +245,9 @@ show_summary() {
   [[ $multi_count -gt 1 ]] && img="${multi_count} images (Ventoy)"
   local bg="${SELECTED_BACKGROUND:-<none>}"
   printf "Images: %s\nDrive: %s\nBackground: %s\n" "$img" "$dev" "$bg"
+  if has_last_download_error; then
+    printf "\n%s\n" "$(last_download_error_summary)"
+  fi
 }
 
 select_image_source() {
@@ -323,8 +327,7 @@ select_images_from_config_multi() {
       output=$(echo "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
     fi
     if [[ ! -f "$output" ]]; then
-      # Script-helpers handles dialog progress + failure details.
-      download_file "$url" "$output" || errs=$((errs+1))
+      download_file_with_error_tracking "$url" "$output" "multi-download" "$id" || errs=$((errs+1))
     fi
     path="$DOWNLOAD_DIR/$output"
     if [[ -f "$path" ]]; then SELECTED_IMAGES+=("$path"); fi
@@ -340,7 +343,7 @@ select_images_from_config_multi() {
       detail="${detail}\nSkipped unsupported URL selections: ${skipped_unsupported[*]}"
     fi
     dialog --title "Download completed with warnings" --msgbox \
-      "Some selected items could not be processed (${errs}).\nThis may be due to missing URLs, unsupported URL schemes, insecure URL rejection, or download failures.\nOnly successfully downloaded files were kept in the selection.${detail}" 14 74
+      "Some selected items could not be processed (${errs}).\nThis may be due to missing URLs, unsupported URL schemes, insecure URL rejection, or download failures.\nOnly successfully downloaded files were kept in the selection.\n\nThe latest download failure remains visible in the main status panel.${detail}" 16 74
   fi
   if [[ ${#SELECTED_IMAGES[@]} -eq 1 ]]; then
     SELECTED_IMAGE="${SELECTED_IMAGES[0]}"
@@ -456,10 +459,8 @@ select_image_from_config() {
     output=$(echo "$url" | sed -E 's|.*/([^/]+\.[^/]+)(/.*)?$|\1|')
   fi
 
-  # Script-helpers handles dialog progress + failure details.
-  if ! download_file "$url" "$output"; then
+  if ! download_file_with_error_tracking "$url" "$output" "single-download" "$chosen"; then
     popd >/dev/null
-    dialog --title "Error" --msgbox "Download failed for: $output" 8 50
     return 1
   fi
 

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -39,6 +39,11 @@ fi
 # shellcheck source=/dev/null
 source "$SCRIPT_HELPERS_DIR/helpers.sh"
 shlib_import logging help dialog file os json deps
+if [[ ! -f "$REPO_ROOT/inc/download-state.sh" ]]; then
+  >&2 printf "Missing required download state helper: %s\n" "$REPO_ROOT/inc/download-state.sh"
+  >&2 printf "Please reinstall burn-iso or restore the missing file and retry.\n"
+  exit 1
+fi
 # shellcheck source=/dev/null
 source "$REPO_ROOT/inc/download-state.sh"
 

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -273,7 +273,6 @@ select_image_source() {
 # Multi-select from config: download chosen ISOs, then select them
 select_images_from_config_multi() {
   dialog_init
-  clear_last_download_error
   load_config
   create_directory "$DOWNLOAD_DIR" >/dev/null || true
   mapfile -t rows < <(jq -r '.distros[] | "\(.id)\t\(.label)\t\(.url)"' "$CONFIG_FILE")
@@ -400,7 +399,6 @@ select_image_local() {
 
 select_image_from_config() {
   dialog_init
-  clear_last_download_error
   load_config
   create_directory "$DOWNLOAD_DIR" >/dev/null || true
 

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -41,7 +41,7 @@ source "$SCRIPT_HELPERS_DIR/helpers.sh"
 shlib_import logging help dialog file os json deps
 if [[ ! -f "$REPO_ROOT/inc/download-state.sh" ]]; then
   >&2 printf "Missing required download state helper: %s\n" "$REPO_ROOT/inc/download-state.sh"
-  >&2 printf "Please reinstall burn-iso or restore the missing file and retry.\n"
+  >&2 printf "Please reinstall Isoforge or restore the missing file and retry.\n"
   exit 1
 fi
 # shellcheck source=/dev/null

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -39,6 +39,7 @@ fi
 # shellcheck source=/dev/null
 source "$SCRIPT_HELPERS_DIR/helpers.sh"
 shlib_import logging help dialog file os json deps
+# shellcheck source=/dev/null
 source "$REPO_ROOT/inc/download-state.sh"
 
 # Always restore a clean terminal UI when exiting (including Cancel/interrupt)
@@ -272,6 +273,7 @@ select_image_source() {
 # Multi-select from config: download chosen ISOs, then select them
 select_images_from_config_multi() {
   dialog_init
+  clear_last_download_error
   load_config
   create_directory "$DOWNLOAD_DIR" >/dev/null || true
   mapfile -t rows < <(jq -r '.distros[] | "\(.id)\t\(.label)\t\(.url)"' "$CONFIG_FILE")
@@ -398,6 +400,7 @@ select_image_local() {
 
 select_image_from_config() {
   dialog_init
+  clear_last_download_error
   load_config
   create_directory "$DOWNLOAD_DIR" >/dev/null || true
 

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -256,17 +256,6 @@ show_summary() {
   fi
 }
 
-show_about_dialog() {
-  dialog_init
-  dialog --title "About burn-iso" --msgbox \
-"burn-iso helps download Linux images and write them to removable media from a dialog-based CLI.
-
-Author profiles
-GitHub: https://github.com/nikolareljin
-LinkedIn: https://www.linkedin.com/in/nikolareljin" \
-    13 76
-}
-
 select_image_source() {
   dialog_init
   local choice
@@ -912,7 +901,6 @@ main_menu() {
       image  "Select Image(s)" \
       bg     "Select Ventoy Background" \
       drive  "Select Drive" \
-      about  "About" \
       flash  "Flash! (dd for single, Ventoy for multi)" \
       quit   "Quit") || break
 
@@ -920,7 +908,6 @@ main_menu() {
       image) if ! run_main_menu_action select_image_source; then :; fi ;;
       bg)    if ! run_main_menu_action select_background_image; then :; fi ;;
       drive) if ! run_main_menu_action select_drive; then :; fi ;;
-      about) show_about_dialog ;;
       flash) if ! run_main_menu_action flash_image; then :; fi ;;
       quit)  break               ;;
     esac

--- a/inc/isoforge.sh
+++ b/inc/isoforge.sh
@@ -334,18 +334,22 @@ select_images_from_config_multi() {
     if [[ -f "$path" ]]; then SELECTED_IMAGES+=("$path"); fi
   done
   popd >/dev/null
-  if (( errs > 0 )); then
-    local detail=""
-    if [[ ${#skipped_insecure[@]} -gt 0 ]]; then
-      detail="${detail}\nSkipped insecure (HTTP) selections: ${skipped_insecure[*]}"
-      detail="${detail}\nHint: set ALLOW_INSECURE_HTTP_DOWNLOADS=1 only if you explicitly accept insecure downloads."
-    fi
+	  if (( errs > 0 )); then
+	    local detail=""
+	    local failure_note="If a download fails, the latest failure remains visible in the main status panel."
+	    if has_last_download_error; then
+	      failure_note="The latest download failure remains visible in the main status panel."
+	    fi
+	    if [[ ${#skipped_insecure[@]} -gt 0 ]]; then
+	      detail="${detail}\nSkipped insecure (HTTP) selections: ${skipped_insecure[*]}"
+	      detail="${detail}\nHint: set ALLOW_INSECURE_HTTP_DOWNLOADS=1 only if you explicitly accept insecure downloads."
+	    fi
     if [[ ${#skipped_unsupported[@]} -gt 0 ]]; then
       detail="${detail}\nSkipped unsupported URL selections: ${skipped_unsupported[*]}"
-    fi
-    dialog --title "Download completed with warnings" --msgbox \
-      "Some selected items could not be processed (${errs}).\nThis may be due to missing URLs, unsupported URL schemes, insecure URL rejection, or download failures.\nOnly successfully downloaded files were kept in the selection.\n\nThe latest download failure remains visible in the main status panel.${detail}" 16 74
-  fi
+	    fi
+	    dialog --title "Download completed with warnings" --msgbox \
+	      "Some selected items could not be processed (${errs}).\nThis may be due to missing URLs, unsupported URL schemes, insecure URL rejection, or download failures.\nOnly successfully downloaded files were kept in the selection.\n\n${failure_note}${detail}" 16 74
+	  fi
   if [[ ${#SELECTED_IMAGES[@]} -eq 1 ]]; then
     SELECTED_IMAGE="${SELECTED_IMAGES[0]}"
   elif [[ ${#SELECTED_IMAGES[@]} -gt 1 ]]; then

--- a/packaging/isoforge.spec
+++ b/packaging/isoforge.spec
@@ -18,10 +18,12 @@ flashing to USB, and creating Ventoy multi-ISO drives.
 %install
 mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/share/isoforge
+mkdir -p %{buildroot}/usr/share/isoforge/inc
 mkdir -p %{buildroot}/usr/share/isoforge/scripts
 mkdir -p %{buildroot}/usr/share/man/man1
 
 install -m 0755 inc/isoforge.sh %{buildroot}/usr/bin/isoforge
+cp -a inc/* %{buildroot}/usr/share/isoforge/inc/
 install -m 0644 config.json %{buildroot}/usr/share/isoforge/config.json
 install -m 0644 VERSION %{buildroot}/usr/share/isoforge/VERSION
 cp -a scripts/* %{buildroot}/usr/share/isoforge/scripts/
@@ -29,6 +31,7 @@ install -m 0644 docs/man/isoforge.1 %{buildroot}/usr/share/man/man1/isoforge.1
 
 %files
 /usr/bin/isoforge
+/usr/share/isoforge/inc
 /usr/share/isoforge/config.json
 /usr/share/isoforge/VERSION
 /usr/share/isoforge/scripts

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -55,9 +55,14 @@ done
 EOF
   chmod +x "$fakebin/curl"
   old_path="$PATH"
+  set +e
   PATH="$fakebin"
   download_file_with_error_tracking "https://example.invalid/success.bin" "$success_file" "batch-download" "DemoItem"
+  success_rc=$?
   PATH="$old_path"
+  [[ "$success_rc" -eq 0 ]]
+  [[ $- != *e* ]]
+  set -e
 
   cli_summary="$(print_last_download_error_cli)"
   [[ "$cli_summary" == *"Ubuntu_24_04"* ]]

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -69,6 +69,51 @@ EOF
   [[ "$cli_summary" == *"Ubuntu_24_04"* ]]
   [[ "$cli_summary" == *"$tmp_log"* ]]
 
+  dash_url_file="$tmpdir/leading-dash.bin"
+  fakebin_dash_url="$tmpdir/fakebin-dash-url"
+  mkdir -p "$fakebin_dash_url"
+  ln -s "$(command -v bash)" "$fakebin_dash_url/bash"
+  for tool in basename dirname mkdir mktemp mv rm wc date tail; do
+    ln -s "$(command -v "$tool")" "$fakebin_dash_url/$tool"
+  done
+  cat >"$fakebin_dash_url/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+seen_double_dash=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    --)
+      seen_double_dash=1
+      shift
+      break
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ "$seen_double_dash" -ne 1 ]]; then
+  echo "missing -- before URL" >&2
+  exit 1
+fi
+if [[ "${1:-}" != "-https://example.invalid/dash.bin" ]]; then
+  echo "unexpected URL: ${1:-}" >&2
+  exit 1
+fi
+: >"$out"
+EOF
+  chmod +x "$fakebin_dash_url/curl"
+  old_path="$PATH"
+  PATH="$fakebin_dash_url"
+  download_file_with_error_tracking "-https://example.invalid/dash.bin" "$dash_url_file" "dash-download" "DashItem"
+  PATH="$old_path"
+  [[ -f "$dash_url_file" ]]
+
   clear_last_download_error
 
   mkdir_fail_root="$tmpdir/mkdir-fail"

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -64,6 +64,77 @@ EOF
   [[ "$cli_summary" == *"$tmp_log"* ]]
 
   clear_last_download_error
+
+  mkdir_fail_root="$tmpdir/mkdir-fail"
+  fakebin_mkdir_fail="$tmpdir/fakebin-mkdir-fail"
+  mkdir -p "$fakebin_mkdir_fail"
+  for tool in basename dirname mktemp mv rm wc date tail; do
+    ln -s "$(command -v "$tool")" "$fakebin_mkdir_fail/$tool"
+  done
+  cat >"$fakebin_mkdir_fail/mkdir" <<'EOF'
+#!/bin/bash
+echo "permission denied" >&2
+exit 1
+EOF
+  chmod +x "$fakebin_mkdir_fail/mkdir"
+  old_path="$PATH"
+  PATH="$fakebin_mkdir_fail"
+  if download_file_with_error_tracking "https://example.invalid/mkdir.bin" "$mkdir_fail_root/out.bin" "mkdir-download" "MkdirItem"; then
+    echo "expected mkdir failure" >&2
+    exit 1
+  fi
+  PATH="$old_path"
+  cli_summary="$(print_last_download_error_cli)"
+  [[ "$cli_summary" == *"mkdir-download MkdirItem"* ]]
+  [[ "$cli_summary" == *"Failed to create output directory"* ]]
+
+  clear_last_download_error
+
+  cancel_file="$tmpdir/cancel.bin"
+  fakebin_dialog="$tmpdir/fakebin-dialog"
+  mkdir -p "$fakebin_dialog"
+  for tool in basename cat dirname mkdir mktemp mv rm wc date tail sleep; do
+    ln -s "$(command -v "$tool")" "$fakebin_dialog/$tool"
+  done
+  cat >"$fakebin_dialog/curl" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf 'partial' >"$out"
+sleep 2
+EOF
+  cat >"$fakebin_dialog/dialog" <<'EOF'
+#!/bin/bash
+cat >/dev/null || true
+exit 1
+EOF
+  chmod +x "$fakebin_dialog/curl" "$fakebin_dialog/dialog"
+  old_path="$PATH"
+  PATH="$fakebin_dialog"
+  if download_file_with_error_tracking "https://example.invalid/cancel.bin" "$cancel_file" "dialog-download" "DialogItem"; then
+    echo "expected dialog cancellation" >&2
+    exit 1
+  else
+    rc=$?
+  fi
+  PATH="$old_path"
+  [[ "$rc" -eq 1 ]]
+  cli_summary="$(print_last_download_error_cli)"
+  [[ "$cli_summary" == *"dialog-download DialogItem"* ]]
+  [[ "$cli_summary" == *"Download canceled by user via dialog."* ]]
+
+  clear_last_download_error
   summary="$(show_summary)"
   [[ "$summary" != *"Last download error:"* ]]
 )

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -170,7 +170,6 @@ sleep 2
 EOF
   cat >"$fakebin_dialog/dialog" <<'EOF'
 #!/usr/bin/env bash
-cat >/dev/null || true
 exit 1
 EOF
   chmod +x "$fakebin_dialog/curl" "$fakebin_dialog/dialog"
@@ -184,9 +183,60 @@ EOF
   fi
   PATH="$old_path"
   [[ "$rc" -eq 1 ]]
+  [[ ! -e "$cancel_file.part" ]]
   cli_summary="$(print_last_download_error_cli)"
   [[ "$cli_summary" == *"dialog-download DialogItem"* ]]
   [[ "$cli_summary" == *"Download canceled by user via dialog."* ]]
+
+  clear_last_download_error
+
+  cleanup_warn_file="$tmpdir/cleanup-warn.bin"
+  cleanup_warn_log_capture="$tmpdir/cleanup-warn.stderr"
+  fakebin_cleanup_warn="$tmpdir/fakebin-cleanup-warn"
+  mkdir -p "$fakebin_cleanup_warn"
+  ln -s "$(command -v bash)" "$fakebin_cleanup_warn/bash"
+  for tool in basename dirname mkdir mktemp mv wc date tail cat; do
+    ln -s "$(command -v "$tool")" "$fakebin_cleanup_warn/$tool"
+  done
+  cat >"$fakebin_cleanup_warn/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+: >"$out"
+EOF
+  cat >"$fakebin_cleanup_warn/rm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+for arg in "$@"; do
+  if [[ "$arg" == /tmp/isoforge-download.*.log ]]; then
+    echo "rm failed intentionally" >&2
+    exit 1
+  fi
+done
+exec /usr/bin/rm "$@"
+EOF
+  chmod +x "$fakebin_cleanup_warn/curl" "$fakebin_cleanup_warn/rm"
+  old_path="$PATH"
+  PATH="$fakebin_cleanup_warn"
+  if ! download_file_with_error_tracking "https://example.invalid/cleanup-warn.bin" "$cleanup_warn_file" "cleanup-download" "CleanupItem" 2>"$cleanup_warn_log_capture"; then
+    echo "expected cleanup warning path to stay successful" >&2
+    exit 1
+  fi
+  PATH="$old_path"
+  [[ -f "$cleanup_warn_file" ]]
+  [[ ! -n "${LAST_DOWNLOAD_ERROR_TIME:-}" ]]
+  [[ "$(cat "$cleanup_warn_log_capture")" == *"warning: failed to remove temporary download log:"* ]]
 
   flow_log="$tmpdir/flow-error.log"
   record_last_download_error \

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -193,6 +193,7 @@ EOF
   cleanup_warn_file="$tmpdir/cleanup-warn.bin"
   cleanup_warn_log_capture="$tmpdir/cleanup-warn.stderr"
   fakebin_cleanup_warn="$tmpdir/fakebin-cleanup-warn"
+  real_rm="$(command -v rm)"
   mkdir -p "$fakebin_cleanup_warn"
   ln -s "$(command -v bash)" "$fakebin_cleanup_warn/bash"
   for tool in basename dirname mkdir mktemp mv wc date tail cat; do
@@ -224,18 +225,18 @@ for arg in "$@"; do
     exit 1
   fi
 done
-exec /usr/bin/rm "$@"
+exec "$REAL_RM" "$@"
 EOF
   chmod +x "$fakebin_cleanup_warn/curl" "$fakebin_cleanup_warn/rm"
   old_path="$PATH"
-  PATH="$fakebin_cleanup_warn"
+  REAL_RM="$real_rm" PATH="$fakebin_cleanup_warn"
   if ! download_file_with_error_tracking "https://example.invalid/cleanup-warn.bin" "$cleanup_warn_file" "cleanup-download" "CleanupItem" 2>"$cleanup_warn_log_capture"; then
     echo "expected cleanup warning path to stay successful" >&2
     exit 1
   fi
   PATH="$old_path"
   [[ -f "$cleanup_warn_file" ]]
-  [[ ! -n "${LAST_DOWNLOAD_ERROR_TIME:-}" ]]
+  [[ -z "${LAST_DOWNLOAD_ERROR_TIME:-}" ]]
   [[ "$(cat "$cleanup_warn_log_capture")" == *"warning: failed to remove temporary download log:"* ]]
 
   flow_log="$tmpdir/flow-error.log"

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -142,6 +142,42 @@ EOF
   [[ "$cli_summary" == *"dialog-download DialogItem"* ]]
   [[ "$cli_summary" == *"Download canceled by user via dialog."* ]]
 
+  flow_log="$tmpdir/flow-error.log"
+  record_last_download_error \
+    "2026-03-11 10:19:00 EDT" \
+    "flow-download" \
+    "FlowItem" \
+    "https://example.invalid/flow.iso" \
+    "$flow_log" \
+    "flow failure" \
+    "1"
+  fakebin_flow="$tmpdir/fakebin-flow"
+  mkdir -p "$fakebin_flow"
+  ln -s "$(command -v bash)" "$fakebin_flow/bash"
+  for tool in jq mkdir sed; do
+    ln -s "$(command -v "$tool")" "$fakebin_flow/$tool"
+  done
+  cat >"$fakebin_flow/dialog" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$fakebin_flow/dialog"
+  old_path="$PATH"
+  old_config_file="$CONFIG_FILE"
+  flow_config="$tmpdir/config.json"
+  cat >"$flow_config" <<'EOF'
+{"distros":[{"id":"DemoISO","label":"Demo ISO","url":"https://example.invalid/demo.iso"}]}
+EOF
+  CONFIG_FILE="$flow_config"
+  PATH="$fakebin_flow"
+  select_image_from_config || true
+  select_images_from_config_multi || true
+  PATH="$old_path"
+  CONFIG_FILE="$old_config_file"
+  cli_summary="$(print_last_download_error_cli)"
+  [[ "$cli_summary" == *"flow-download FlowItem"* ]]
+  [[ "$cli_summary" == *"$flow_log"* ]]
+
   tracked_log="$(mktemp "/tmp/isoforge-download.XXXXXXXX.log")"
   printf 'temporary tracked failure\n' >"$tracked_log"
   record_last_download_error \

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+(
+  cd "$ROOT_DIR"
+  export ISOFORGE_DISABLE_EXIT_TRAP=1
+  source ./inc/isoforge.sh
+
+  record_last_download_error \
+    "2026-03-11 10:15:00 EDT" \
+    "single-download" \
+    "Ubuntu_24_04" \
+    "https://example.invalid/ubuntu.iso" \
+    "/tmp/isoforge-download.test.log" \
+    "curl: (22) The requested URL returned error: 404" \
+    "22"
+
+  summary="$(show_summary)"
+  [[ "$summary" == *"Last download error:"* ]]
+  [[ "$summary" == *"single-download Ubuntu_24_04"* ]]
+  [[ "$summary" == *"/tmp/isoforge-download.test.log"* ]]
+  [[ "$summary" == *"404"* ]]
+
+  clear_last_download_error
+  summary="$(show_summary)"
+  [[ "$summary" != *"Last download error:"* ]]
+)

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -6,22 +6,62 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 (
   cd "$ROOT_DIR"
   export ISOFORGE_DISABLE_EXIT_TRAP=1
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' EXIT
   source ./inc/isoforge.sh
 
+  tmp_log="$tmpdir/error.log"
   record_last_download_error \
     "2026-03-11 10:15:00 EDT" \
     "single-download" \
     "Ubuntu_24_04" \
     "https://example.invalid/ubuntu.iso" \
-    "/tmp/isoforge-download.test.log" \
+    "$tmp_log" \
     "curl: (22) The requested URL returned error: 404" \
     "22"
 
   summary="$(show_summary)"
   [[ "$summary" == *"Last download error:"* ]]
   [[ "$summary" == *"single-download Ubuntu_24_04"* ]]
-  [[ "$summary" == *"/tmp/isoforge-download.test.log"* ]]
+  [[ "$summary" == *"$tmp_log"* ]]
   [[ "$summary" == *"404"* ]]
+
+  cli_summary="$(print_last_download_error_cli)"
+  [[ "$cli_summary" == *"Last download error:"* ]]
+  [[ "$cli_summary" == *"$tmp_log"* ]]
+
+  success_file="$tmpdir/success.bin"
+  fakebin="$tmpdir/fakebin"
+  mkdir -p "$fakebin"
+  for tool in basename dirname mkdir mktemp mv rm wc date tail; do
+    ln -s "$(command -v "$tool")" "$fakebin/$tool"
+  done
+  cat >"$fakebin/curl" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+: >"$out"
+EOF
+  chmod +x "$fakebin/curl"
+  old_path="$PATH"
+  PATH="$fakebin"
+  download_file_with_error_tracking "https://example.invalid/success.bin" "$success_file" "batch-download" "DemoItem"
+  PATH="$old_path"
+
+  cli_summary="$(print_last_download_error_cli)"
+  [[ "$cli_summary" == *"Ubuntu_24_04"* ]]
+  [[ "$cli_summary" == *"$tmp_log"* ]]
 
   clear_last_download_error
   summary="$(show_summary)"

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -113,6 +113,7 @@ EOF
   download_file_with_error_tracking "-https://example.invalid/dash.bin" "$dash_url_file" "dash-download" "DashItem"
   PATH="$old_path"
   [[ -f "$dash_url_file" ]]
+  [[ "$(derive_download_output_name "-https://example.invalid/dash.bin")" == "dash.bin" ]]
 
   clear_last_download_error
 
@@ -262,6 +263,58 @@ EOF
 
   clear_last_download_error
   [[ ! -e "$second_tracked_log" ]]
+
+  stale_log="$tmpdir/stale-error.log"
+  record_last_download_error \
+    "2026-03-11 10:23:00 EDT" \
+    "stale-download" \
+    "StaleItem" \
+    "https://example.invalid/stale.iso" \
+    "$stale_log" \
+    "stale failure" \
+    "1"
+  warning_capture="$tmpdir/multi-warning.txt"
+  fakebin_multi_warning="$tmpdir/fakebin-multi-warning"
+  mkdir -p "$fakebin_multi_warning"
+  ln -s "$(command -v bash)" "$fakebin_multi_warning/bash"
+  for tool in jq mkdir sed cat; do
+    ln -s "$(command -v "$tool")" "$fakebin_multi_warning/$tool"
+  done
+  cat >"$fakebin_multi_warning/dialog" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  --stdout)
+    printf '"DemoISO"\n'
+    exit 0
+    ;;
+  --title)
+    if [[ "${2:-}" == "Download completed with warnings" && "${3:-}" == "--msgbox" ]]; then
+      printf '%s\n' "${4:-}" >"$WARNING_CAPTURE_FILE"
+      exit 0
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+EOF
+  chmod +x "$fakebin_multi_warning/dialog"
+  multi_warning_config="$tmpdir/multi-warning-config.json"
+  cat >"$multi_warning_config" <<'EOF'
+{"distros":[{"id":"DemoISO","label":"Demo ISO","url":"ftp://example.invalid/demo.iso"}]}
+EOF
+  old_path="$PATH"
+  old_config_file="$CONFIG_FILE"
+  CONFIG_FILE="$multi_warning_config"
+  WARNING_CAPTURE_FILE="$warning_capture" PATH="$fakebin_multi_warning" select_images_from_config_multi || true
+  PATH="$old_path"
+  CONFIG_FILE="$old_config_file"
+  [[ -f "$warning_capture" ]]
+  warning_text="$(cat "$warning_capture")"
+  [[ "$warning_text" == *"If a download fails, the latest failure remains visible in the main status panel."* ]]
+  [[ "$warning_text" != *"The latest download failure remains visible in the main status panel."* ]]
+
+  clear_last_download_error
   summary="$(show_summary)"
   [[ "$summary" != *"Last download error:"* ]]
 )

--- a/scripts/test-download-error-state.sh
+++ b/scripts/test-download-error-state.sh
@@ -33,11 +33,12 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
   success_file="$tmpdir/success.bin"
   fakebin="$tmpdir/fakebin"
   mkdir -p "$fakebin"
+  ln -s "$(command -v bash)" "$fakebin/bash"
   for tool in basename dirname mkdir mktemp mv rm wc date tail; do
     ln -s "$(command -v "$tool")" "$fakebin/$tool"
   done
   cat >"$fakebin/curl" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 out=""
 while [[ $# -gt 0 ]]; do
@@ -73,11 +74,12 @@ EOF
   mkdir_fail_root="$tmpdir/mkdir-fail"
   fakebin_mkdir_fail="$tmpdir/fakebin-mkdir-fail"
   mkdir -p "$fakebin_mkdir_fail"
+  ln -s "$(command -v bash)" "$fakebin_mkdir_fail/bash"
   for tool in basename dirname mktemp mv rm wc date tail; do
     ln -s "$(command -v "$tool")" "$fakebin_mkdir_fail/$tool"
   done
   cat >"$fakebin_mkdir_fail/mkdir" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "permission denied" >&2
 exit 1
 EOF
@@ -98,11 +100,12 @@ EOF
   cancel_file="$tmpdir/cancel.bin"
   fakebin_dialog="$tmpdir/fakebin-dialog"
   mkdir -p "$fakebin_dialog"
+  ln -s "$(command -v bash)" "$fakebin_dialog/bash"
   for tool in basename cat dirname mkdir mktemp mv rm wc date tail sleep; do
     ln -s "$(command -v "$tool")" "$fakebin_dialog/$tool"
   done
   cat >"$fakebin_dialog/curl" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 out=""
 while [[ $# -gt 0 ]]; do
@@ -120,7 +123,7 @@ printf 'partial' >"$out"
 sleep 2
 EOF
   cat >"$fakebin_dialog/dialog" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 cat >/dev/null || true
 exit 1
 EOF
@@ -139,7 +142,45 @@ EOF
   [[ "$cli_summary" == *"dialog-download DialogItem"* ]]
   [[ "$cli_summary" == *"Download canceled by user via dialog."* ]]
 
+  tracked_log="$(mktemp "/tmp/isoforge-download.XXXXXXXX.log")"
+  printf 'temporary tracked failure\n' >"$tracked_log"
+  record_last_download_error \
+    "2026-03-11 10:20:00 EDT" \
+    "tracked-download" \
+    "TrackedItem" \
+    "https://example.invalid/tracked.iso" \
+    "$tracked_log" \
+    "tracked failure" \
+    "1"
+  [[ -f "$tracked_log" ]]
   clear_last_download_error
+  [[ ! -e "$tracked_log" ]]
+
+  first_tracked_log="$(mktemp "/tmp/isoforge-download.XXXXXXXX.log")"
+  second_tracked_log="$(mktemp "/tmp/isoforge-download.XXXXXXXX.log")"
+  printf 'first tracked failure\n' >"$first_tracked_log"
+  printf 'second tracked failure\n' >"$second_tracked_log"
+  record_last_download_error \
+    "2026-03-11 10:21:00 EDT" \
+    "tracked-download" \
+    "TrackedItemOne" \
+    "https://example.invalid/tracked-one.iso" \
+    "$first_tracked_log" \
+    "first tracked failure" \
+    "1"
+  record_last_download_error \
+    "2026-03-11 10:22:00 EDT" \
+    "tracked-download" \
+    "TrackedItemTwo" \
+    "https://example.invalid/tracked-two.iso" \
+    "$second_tracked_log" \
+    "second tracked failure" \
+    "2"
+  [[ ! -e "$first_tracked_log" ]]
+  [[ -e "$second_tracked_log" ]]
+
+  clear_last_download_error
+  [[ ! -e "$second_tracked_log" ]]
   summary="$(show_summary)"
   [[ "$summary" != *"Last download error:"* ]]
 )

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -47,6 +47,7 @@ cd "$ROOT_DIR"
 ./scripts/build.sh
 ./scripts/test-cancel-flow.sh
 ./scripts/test-flash-drive-redirect.sh
+./scripts/test-download-error-state.sh
 
 if command -v jq >/dev/null 2>&1; then
     jq -e '.distros and (.distros | type == "array")' config.json >/dev/null


### PR DESCRIPTION
## Summary
- persist the latest download failure summary, URL, timestamp, and /tmp log path in shared session state
- surface that state in the isoforge main summary and in the standalone download command output
- add regression coverage for persisted error summary visibility and document the behavior in the changelog

## Validation
- ./scripts/build.sh
- ./scripts/test.sh --no-shellcheck
- ./scripts/test.sh (fails locally: shellcheck not installed)

Resolves #9