### PR TITLE
fix: SSH → HTTPS submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 
 [submodule "image-view"]
 	path = image-view
-	url = git@github.com:nikolareljin/image-view.git
+	url = https://github.com/nikolareljin/image-view.git


### PR DESCRIPTION
Replace SSH submodule URLs with HTTPS so CI runners can fetch submodules without deploy keys.

- `.gitmodules`: `git@github.com:` → `https://github.com/`